### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Chicken/Chicken.pkg.recipe
+++ b/Chicken/Chicken.pkg.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Chicken.app</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/Applications/Chicken.app</string>
             </dict>

--- a/ScreenFlow/ScreenFlow.download.recipe
+++ b/ScreenFlow/ScreenFlow.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/ScreenFlow.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WSG985FR47</string>
 			</dict>

--- a/ScreenFlow/ScreenFlow.filewave.recipe
+++ b/ScreenFlow/ScreenFlow.filewave.recipe
@@ -17,7 +17,7 @@
 		<key>fw_app_version</key>
 		<string>%version%</string>
 		<key>fw_destination_root</key>
-		<string>/Applications/%NAME%.app</string>
+		<string>/Applications/ScreenFlow.app</string>
 		<key>fw_fileset_group</key>
 		<string></string>
 	</dict>
@@ -41,7 +41,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/ScreenFlow.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.johncclayton.filewave.FWTool/FileWaveImporter</string>

--- a/ScreenFlow/ScreenFlow.install.recipe
+++ b/ScreenFlow/ScreenFlow.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>ScreenFlow.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/ScreenFlow/ScreenFlow.pkg.recipe
+++ b/ScreenFlow/ScreenFlow.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/ScreenFlow.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/ScreenFlow.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/SpringToolSuite/SpringToolSuite.install.recipe
+++ b/SpringToolSuite/SpringToolSuite.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>sts-bundle/%NAME%.app</string>
+						<string>sts-bundle/Spring Tool Suite.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/YakYak/YakYak.install.recipe
+++ b/YakYak/YakYak.install.recipe
@@ -54,7 +54,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>YakYak.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/YakYak/YakYak.pkg.recipe
+++ b/YakYak/YakYak.pkg.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/YakYak-darwin-x64/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/YakYak-darwin-x64/YakYak.app</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.