### PR TITLE
Deprecate Masergy Communicator recipes

### DIFF
--- a/MasergyCommunicator/MasergyCommunicator.download.recipe
+++ b/MasergyCommunicator/MasergyCommunicator.download.recipe
@@ -16,9 +16,18 @@
 		<string>MasergyCommunicator</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.5.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Masergy is now part of Comcast Business (details: https://business.comcast.com/masergy), and the Masergy Communicator app is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the Masergy Communicator recipes, since the software is no longer available for download.