### PR TITLE
Deprecate Collibra recipes

### DIFF
--- a/Collibra/Collibra.download.recipe
+++ b/Collibra/Collibra.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Collibra for Desktop is end of life effective October 2024 (details: https://productresources.collibra.com/docs/collibra/latest/Content/to_collibra-everywhere.htm). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
This PR deprecates the Collibra recipes, since the software is end of life effective October 2024 ([details](https://productresources.collibra.com/docs/collibra/latest/Content/to_collibra-everywhere.htm)).
