### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Chicken/Chicken.pkg.recipe
+++ b/Chicken/Chicken.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>net.sourceforge.chicken.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Console/Console.pkg.recipe
+++ b/Console/Console.pkg.recipe
@@ -39,8 +39,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/MasergyCommunicator/MasergyCommunicator.pkg.recipe
+++ b/MasergyCommunicator/MasergyCommunicator.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>com.masergy.communicator</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/ScreenFlow/ScreenFlow.pkg.recipe
+++ b/ScreenFlow/ScreenFlow.pkg.recipe
@@ -64,8 +64,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SpringToolSuite/SpringToolSuite.pkg.recipe
+++ b/SpringToolSuite/SpringToolSuite.pkg.recipe
@@ -69,8 +69,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>version</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._