### PR TITLE
Add NotchLC recipes

### DIFF
--- a/NotchLC/NotchLC.download.recipe
+++ b/NotchLC/NotchLC.download.recipe
@@ -32,7 +32,22 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https://[^"]+\.pkg</string>
+				<string>(https://[^"]+\.pkg)</string>
+				<key>result_output_var_name</key>
+				<string>pkg_url</string>
+				<key>url</key>
+				<string>%match%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>Plugin_([\d\.]+[a-z]?)_macOS\.pkg</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
 				<key>url</key>
 				<string>%match%</string>
 			</dict>
@@ -45,7 +60,7 @@
 				<key>filename</key>
 				<string>%NAME%.pkg</string>
 				<key>url</key>
-				<string>%match%</string>
+				<string>%pkg_url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/NotchLC/NotchLC.download.recipe
+++ b/NotchLC/NotchLC.download.recipe
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of NotchLC Adobe CC Plugin.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.download.notchlc</string>
+	<key>Input</key>
+	<dict>
+		<key>DOWNLOAD_PAGE</key>
+		<string>https://notchlc.notch.one/</string>
+		<key>NAME</key>
+		<string>NotchLC</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>https://go\.notch\.one/notchlc-[\d\-]+-macos</string>
+				<key>url</key>
+				<string>%DOWNLOAD_PAGE%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>https://[^"]+\.pkg</string>
+				<key>url</key>
+				<string>%match%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
+				<key>url</key>
+				<string>%match%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: 10bit FX Limited (84ZPL6724B)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/NotchLC/NotchLC.pkg.recipe
+++ b/NotchLC/NotchLC.pkg.recipe
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of NotchLC Adobe CC Plugin and copies the pkg to the recipe cache.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.notchlc</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>NotchLC</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.rderewianko.download.notchlc</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/NotchLC/NotchLC.pkg.recipe
+++ b/NotchLC/NotchLC.pkg.recipe
@@ -20,6 +20,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/NotchLC-%version%.pkg</string>
 				<key>source_pkg</key>
 				<string>%pathname%</string>
 			</dict>


### PR DESCRIPTION
## Summary
Add recipes for NotchLC Adobe CC Plugin (video codec plugin).

### NotchLC
- `com.rderewianko.download.notchlc` - Downloads the PKG from notchlc.notch.one
- `com.rderewianko.pkg.notchlc` - Copies the pkg to the recipe cache

**Note:** Uses chained URLTextSearcher to find download URL since the page uses meta refresh redirects.

## Test plan
- [ ] Run `autopkg run com.rderewianko.download.notchlc`
- [ ] Run `autopkg run com.rderewianko.pkg.notchlc`