### PR TITLE
Add 1Password CLI pkg recipe

### DIFF
--- a/1Password_CLI/1Password_CLI.pkg.recipe
+++ b/1Password_CLI/1Password_CLI.pkg.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of 1Password CLI and copies the pkg to the recipe cache.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.1password_cli</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>1Password CLI</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.apettinen.download.1Password_CLI</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/1PasswordCLI-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds a `.pkg` recipe for 1Password CLI using `apettinen-recipes` download recipe as parent
- Uses `PkgCopier` since the upstream download is already a `.pkg`
- Suitable for use with KAPPA for Kandji uploads

## Test plan
- [x] Run `autopkg run 1Password_CLI.pkg` and verify pkg is produced in recipe cache
- [x] Verify KAPPA integration with `autopkg run 1Password_CLI.pkg --post io.kandji.kappa/KAPPA`