### PR TITLE
Add Cypherock CySync recipes

### DIFF
--- a/CypherockCySync/CypherockCySync.download.recipe
+++ b/CypherockCySync/CypherockCySync.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/Cypherock CySync.app/Contents/Info.plist</string>
+				<string>%pathname%/cypherock-cysync.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/CypherockCySync/CypherockCySync.download.recipe
+++ b/CypherockCySync/CypherockCySync.download.recipe
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Cypherock CySync.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.download.cypherockcysync</string>
+	<key>Input</key>
+	<dict>
+		<key>GITHUB_REPO</key>
+		<string>Cypherock/cypherock-cysync</string>
+		<key>NAME</key>
+		<string>Cypherock CySync</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>cypherock-cysync-.*-darwin-universal\.dmg</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/Cypherock CySync.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/CypherockCySync/CypherockCySync.pkg.recipe
+++ b/CypherockCySync/CypherockCySync.pkg.recipe
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Cypherock CySync and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.cypherockcysync</string>
+	<key>Input</key>
+	<dict>
+		<key>BUNDLE_ID</key>
+		<string>com.hodl.cypherock</string>
+		<key>NAME</key>
+		<string>Cypherock CySync</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.rderewianko.download.cypherockcysync</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%pkgroot%/Applications/Cypherock CySync.app</string>
+				<key>source_path</key>
+				<string>%pathname%/Cypherock CySync.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_request</key>
+				<dict>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>group</key>
+							<string>admin</string>
+							<key>path</key>
+							<string>Applications</string>
+							<key>user</key>
+							<string>root</string>
+						</dict>
+					</array>
+					<key>id</key>
+					<string>%BUNDLE_ID%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
+					<key>pkgroot</key>
+					<string>%pkgroot%</string>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/CypherockCySync/CypherockCySync.pkg.recipe
+++ b/CypherockCySync/CypherockCySync.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Cypherock CySync.app</string>
+				<string>%pkgroot%/Applications/cypherock-cysync.app</string>
 				<key>source_path</key>
-				<string>%pathname%/Cypherock CySync.app</string>
+				<string>%pathname%/cypherock-cysync.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
## Summary
- Adds download and pkg recipes for Cypherock CySync desktop wallet app
- Downloads universal DMG from GitHub releases via `GitHubReleasesInfoProvider`
- Packages the `.app` into a `.pkg` for Kandji/KAPPA deployment

## Test plan
- [x] Run `autopkg run CypherockCySync.download` and verify DMG downloads
- [x] Run `autopkg run CypherockCySync.pkg` and verify pkg is created
- [x] Verify KAPPA integration with `autopkg run CypherockCySync.pkg --post io.kandji.kappa/KAPPA`