### PR TITLE
Add Burp Suite Professional pkg recipe

### DIFF
--- a/Burp Suite Professional/Burp Suite Professional.pkg.recipe
+++ b/Burp Suite Professional/Burp Suite Professional.pkg.recipe
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Burp Suite Professional and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.burpsuiteprofessional</string>
+	<key>Input</key>
+	<dict>
+		<key>BUNDLE_ID</key>
+		<string>com.portswigger.burpsuiteprofessional</string>
+		<key>NAME</key>
+		<string>BurpSuiteProfessional</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.dataJAR-recipes.download.Burp Suite Professional</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%pkgroot%/Applications/Burp Suite Professional.app</string>
+				<key>source_path</key>
+				<string>%pathname%/Burp Suite Professional.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_request</key>
+				<dict>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>group</key>
+							<string>admin</string>
+							<key>path</key>
+							<string>Applications</string>
+							<key>user</key>
+							<string>root</string>
+						</dict>
+					</array>
+					<key>id</key>
+					<string>%BUNDLE_ID%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%VERSION%</string>
+					<key>pkgroot</key>
+					<string>%pkgroot%</string>
+					<key>version</key>
+					<string>%VERSION%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds a pkg recipe for Burp Suite Professional using the dataJAR download recipe as parent
- Packages the .app from the DMG into a .pkg for deployment

## Test plan
- [x] `autopkg run "Burp Suite Professional.pkg"` — built `BurpSuiteProfessional-2025.12.5.pkg` successfully