### PR TITLE
Add YubicoPivTool download and pkg recipes

### DIFF
--- a/YubicoPivTool/YubicoPivTool.download.recipe
+++ b/YubicoPivTool/YubicoPivTool.download.recipe
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest Yubico PIV Tool installer package.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.download.YubicoPivTool</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>YubicoPivTool</string>
+		<key>DOWNLOAD_URL</key>
+		<string>https://developers.yubico.com/yubico-piv-tool/Releases/</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>re_pattern</key>
+				<string>href="(yubico-piv-tool-[0-9\.]+-mac-universal\.pkg)"</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>re_pattern</key>
+				<string>href="yubico-piv-tool-([0-9\.]+)-mac-universal\.pkg"</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%%match%</string>
+				<key>filename</key>
+				<string>%NAME%-%version%.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Yubico Limited (LQA3CS5MM7)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/YubicoPivTool/YubicoPivTool.download.recipe
+++ b/YubicoPivTool/YubicoPivTool.download.recipe
@@ -8,10 +8,10 @@
 	<string>com.rderewianko.download.YubicoPivTool</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>YubicoPivTool</string>
 		<key>DOWNLOAD_URL</key>
 		<string>https://developers.yubico.com/yubico-piv-tool/Releases/</string>
+		<key>NAME</key>
+		<string>YubicoPivTool</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.3</string>
@@ -20,10 +20,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
 				<string>href="(yubico-piv-tool-[0-9\.]+-mac-universal\.pkg)"</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -31,12 +31,12 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
 				<key>re_pattern</key>
 				<string>href="yubico-piv-tool-([0-9\.]+)-mac-universal\.pkg"</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -44,10 +44,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%%match%</string>
 				<key>filename</key>
 				<string>%NAME%-%version%.pkg</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -59,14 +59,14 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_path</key>
-				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: Yubico Limited (LQA3CS5MM7)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/YubicoPivTool/YubicoPivTool.pkg.recipe
+++ b/YubicoPivTool/YubicoPivTool.pkg.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest Yubico PIV Tool and copies the installer package.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.YubicoPivTool</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>YubicoPivTool</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>ParentRecipe</key>
+	<string>com.rderewianko.download.YubicoPivTool</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds download and pkg recipes for Yubico PIV Tool
- Download recipe fetches the latest universal macOS pkg from Yubico's releases page with code signature verification
- Pkg recipe copies the installer package with versioned output naming (e.g. `YubicoPivTool-2.7.3.pkg`)

## Test plan
- [x] Ran `autopkg run -v` locally — downloaded v2.7.3, signature verified, pkg copied successfully