### PR TITLE
Add NVIDIA Nsight Compute recipes

### DIFF
--- a/NVIDIANsightCompute/NVIDIANsightCompute.download.recipe
+++ b/NVIDIANsightCompute/NVIDIANsightCompute.download.recipe
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest NVIDIA Nsight Compute for macOS. Set ARCH to "arm64" (default) for Apple Silicon or "x86_64" for Intel.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.download.NVIDIANsightCompute</string>
+	<key>Input</key>
+	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
+		<key>NAME</key>
+		<string>NVIDIANsightCompute</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>downloads/assets/tools/secure/nsight-compute/[^/]+/nsight_compute-mac-%ARCH%-[^"]+\.dmg</string>
+				<key>url</key>
+				<string>https://developer.nvidia.com/tools-overview/nsight-compute/get-started</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>nsight_compute-mac-%ARCH%-([0-9.]+)\.dmg</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+				<key>url</key>
+				<string>https://developer.nvidia.com/tools-overview/nsight-compute/get-started</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.dmg</string>
+				<key>url</key>
+				<string>https://developer.nvidia.com/%match%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/NVIDIA Nsight Compute.app</string>
+				<key>requirement</key>
+				<string>identifier "com.nvidia.devtools.Rebel" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6KR3T733EC"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/NVIDIANsightCompute/NVIDIANsightCompute.pkg.recipe
+++ b/NVIDIANsightCompute/NVIDIANsightCompute.pkg.recipe
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest NVIDIA Nsight Compute for macOS and creates a package. Set ARCH to "arm64" (default) for Apple Silicon or "x86_64" for Intel.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.NVIDIANsightCompute</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>NVIDIANsightCompute</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>ParentRecipe</key>
+	<string>com.rderewianko.download.NVIDIANsightCompute</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkgdirs</key>
+				<dict>
+					<key>Applications</key>
+					<string>0775</string>
+				</dict>
+				<key>pkgroot</key>
+				<string>%RECIPE_CACHE_DIR%/build</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgRootCreator</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%pkgroot%/Applications/NVIDIA Nsight Compute.app</string>
+				<key>source_path</key>
+				<string>%pathname%/NVIDIA Nsight Compute.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>Copier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_request</key>
+				<dict>
+					<key>chown</key>
+					<array>
+						<dict>
+							<key>group</key>
+							<string>admin</string>
+							<key>path</key>
+							<string>Applications</string>
+							<key>user</key>
+							<string>root</string>
+						</dict>
+					</array>
+					<key>id</key>
+					<string>com.nvidia.devtools.Rebel</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
+					<key>pkgroot</key>
+					<string>%pkgroot%</string>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds download and pkg recipes for NVIDIA Nsight Compute (CUDA/OptiX GPU profiler)
- Scrapes the NVIDIA developer download page for the latest macOS DMG
- Supports architecture selection via `ARCH` input (`arm64` default, `x86_64` for Intel)
- Includes code signature verification against NVIDIA Corporation's Developer ID

## Test plan
- [x] Verified download recipe successfully finds and downloads latest DMG (v2025.4.1.3)
- [x] Verified code signature validation passes
- [x] Verified pkg recipe builds installer package from DMG contents