### PR TITLE
Add NodeJS pkg recipe

### DIFF
--- a/NodeJS/NodeJS.pkg.recipe
+++ b/NodeJS/NodeJS.pkg.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Node.js and copies the installer package.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.NodeJS</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>NodeJS</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>ParentRecipe</key>
+	<string>com.github.gerardkok.download.node</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds a NodeJS pkg recipe that uses `com.github.gerardkok.download.node` as the parent download recipe
- Uses `PkgCopier` to copy the downloaded .pkg to a standardized output path

## Test plan
- [x] Run `autopkg run NodeJS.pkg.recipe` and verify it downloads and copies the Node.js installer package
- [x] Verify code signature validation passes