### PR TITLE
fixing by mioving to gh processor

### DIFF
--- a/CodexCLI/CodexCLI.download.recipe
+++ b/CodexCLI/CodexCLI.download.recipe
@@ -3,44 +3,37 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI from GitHub.</string>
+	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI from GitHub.
+
+Uses GitHubReleasesInfoProvider so the API call is authenticated via AutoPkg's
+standard GITHUB_TOKEN preference (or ~/.config/github_token), avoiding the
+60-req/hour unauthenticated rate limit that was causing URLTextSearcher to
+fail intermittently on shared CI runners.</string>
 	<key>Identifier</key>
 	<string>com.rderewianko.download.CodexCLI</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>CodexCLI</string>
+		<key>GITHUB_REPO</key>
+		<string>openai/codex</string>
+		<key>ASSET_REGEX</key>
+		<string>^codex-aarch64-apple-darwin\.tar\.gz$</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>2.3</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>curl_opts</key>
-				<array>
-					<string>--retry</string>
-					<string>3</string>
-					<string>--retry-delay</string>
-					<string>5</string>
-				</array>
-				<key>re_pattern</key>
-				<string>"browser_download_url":\s*"(?P&lt;download_url&gt;https://github\.com/openai/codex/releases/download/(?P&lt;tag&gt;[^"/]*?(?P&lt;version&gt;\d+\.\d+\.\d+)[^"/]*)/codex-aarch64-apple-darwin\.tar\.gz)"</string>
-				<key>request_headers</key>
-				<dict>
-					<key>Accept</key>
-					<string>application/vnd.github+json</string>
-					<key>X-GitHub-Api-Version</key>
-					<string>2022-11-28</string>
-				</dict>
-				<key>result_output_var_name</key>
-				<string>download_url</string>
-				<key>url</key>
-				<string>https://api.github.com/repos/openai/codex/releases/latest</string>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -48,7 +41,7 @@
 				<key>filename</key>
 				<string>%NAME%-%version%-aarch64-apple-darwin.tar.gz</string>
 				<key>url</key>
-				<string>%download_url%</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
CodexCLI: use GitHubReleasesInfoProvider for authenticated API access

URLTextSearcher was hitting the GitHub API unauthenticated and getting
rate-limited (60 req/hour per IP) on shared CI runners, causing
intermittent "No match found on URL" failures. Replacing it with
GitHubReleasesInfoProvider routes the API call through AutoPkg's
standard authenticated GitHubSession, which reads the token from the
GITHUB_TOKEN preference or ~/.config/github_token.

Asset selection is preserved via asset_regex, kept as an Input key so
downstream consumers can override it (e.g. to pin to the .dmg instead
of the tar.gz).

Behavior change to note: GitHubReleasesInfoProvider sets %version% from
the release tag (only a leading "v" is stripped). openai/codex uses
multi-product tags like "rust-v0.121.0", so %version% becomes
"rust-v0.121.0" rather than the "0.121.0" URLTextSearcher was
extracting via regex. Consumers tracking version strings will see this
as a one-time transition.