### PR TITLE
Deprecate NodeJS.pkg recipe, redirect to novaksam-recipes

### DIFF
--- a/NodeJS/NodeJS.pkg.recipe
+++ b/NodeJS/NodeJS.pkg.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe is deprecated and will be removed on July 21, 2026. Please use com.github.novaksam.pkg.NodeJS (https://github.com/autopkg/novaksam-recipes) instead.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>

--- a/NodeJS/NodeJS.pkg.recipe
+++ b/NodeJS/NodeJS.pkg.recipe
@@ -18,13 +18,13 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>DeprecationWarning</string>
 			<key>Arguments</key>
 			<dict>
 				<key>warning_message</key>
 				<string>This recipe is deprecated and will be removed on July 21, 2026. Please use com.github.novaksam.pkg.NodeJS (https://github.com/autopkg/novaksam-recipes) instead.</string>
 			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>


### PR DESCRIPTION
## Summary
- Adds a `DeprecationWarning` processor to `NodeJS/NodeJS.pkg.recipe` pointing users to `com.github.novaksam.pkg.NodeJS` in [novaksam-recipes](https://github.com/autopkg/novaksam-recipes).
- Scheduled for removal on July 21, 2026, aligning with the upstream `com.github.gerardkok.download.node` parent recipe's own deprecation timeline.

## Test plan
- [ ] Run `autopkg run NodeJS.pkg` and confirm the deprecation warning is emitted
- [ ] Confirm the package still builds as before