### PR TITLE
Revert CodexCLI download recipe to URLTextSearcher for clean version

### DIFF
--- a/CodexCLI/CodexCLI.download.recipe
+++ b/CodexCLI/CodexCLI.download.recipe
@@ -3,37 +3,30 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI from GitHub.
-
-Uses GitHubReleasesInfoProvider so the API call is authenticated via AutoPkg's
-standard GITHUB_TOKEN preference (or ~/.config/github_token), avoiding the
-60-req/hour unauthenticated rate limit that was causing URLTextSearcher to
-fail intermittently on shared CI runners.</string>
+	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI from GitHub.</string>
 	<key>Identifier</key>
 	<string>com.rderewianko.download.CodexCLI</string>
 	<key>Input</key>
 	<dict>
-		<key>ASSET_REGEX</key>
-		<string>^codex-aarch64-apple-darwin\.tar\.gz$</string>
-		<key>GITHUB_REPO</key>
-		<string>openai/codex</string>
 		<key>NAME</key>
 		<string>CodexCLI</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>2.3</string>
+	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>asset_regex</key>
-				<string>%ASSET_REGEX%</string>
-				<key>github_repo</key>
-				<string>%GITHUB_REPO%</string>
+				<key>re_pattern</key>
+				<string>"tag_name":\s*"rust-v([0-9]+\.[0-9]+\.[0-9]+)"</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+				<key>url</key>
+				<string>https://api.github.com/repos/openai/codex/releases/latest</string>
 			</dict>
 			<key>Processor</key>
-			<string>GitHubReleasesInfoProvider</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -41,7 +34,7 @@ fail intermittently on shared CI runners.</string>
 				<key>filename</key>
 				<string>%NAME%-%version%-aarch64-apple-darwin.tar.gz</string>
 				<key>url</key>
-				<string>%url%</string>
+				<string>https://github.com/openai/codex/releases/download/rust-v%version%/codex-aarch64-apple-darwin.tar.gz</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
## Summary
- `GitHubReleasesInfoProvider` set `%version%` to the raw git tag (`rust-v0.X.Y`), which `PkgCreator` rejects with `Invalid version component "rust-v0"`, breaking every nightly AutoPkg run for CodexCLI.
- Reverts to `URLTextSearcher` with a regex that captures only the numeric version from `tag_name`. The rate-limit concern that motivated the original switch hasn't actually been hitting us in practice.

## Test plan
- [x] `autopkg run` against the IT override downloads and builds `CodexCLI-0.124.0.pkg` successfully
- [x] Nightly AutoPkg workflow in IT repo passes after trust-info refresh (follow-up)