### PR TITLE
Use GitHubReleasesInfoProvider + FindAndReplace for CodexCLI version

### DIFF
--- a/CodexCLI/CodexCLI.download.recipe
+++ b/CodexCLI/CodexCLI.download.recipe
@@ -3,30 +3,54 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI from GitHub.</string>
+	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI from GitHub.
+
+Uses GitHubReleasesInfoProvider for authenticated API calls (avoids the
+60-req/hour unauthenticated rate limit on shared CI runners), then
+FindAndReplace strips the "rust-v" prefix from the tag so %version% is
+a clean semver acceptable to PkgCreator.</string>
 	<key>Identifier</key>
 	<string>com.rderewianko.download.CodexCLI</string>
 	<key>Input</key>
 	<dict>
+		<key>ASSET_REGEX</key>
+		<string>^codex-aarch64-apple-darwin\.tar\.gz$</string>
+		<key>GITHUB_REPO</key>
+		<string>openai/codex</string>
 		<key>NAME</key>
 		<string>CodexCLI</string>
+		<key>TAG_PREFIX</key>
+		<string>rust-v</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>2.7.6</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>"tag_name":\s*"rust-v([0-9]+\.[0-9]+\.[0-9]+)"</string>
-				<key>result_output_var_name</key>
-				<string>version</string>
-				<key>url</key>
-				<string>https://api.github.com/repos/openai/codex/releases/latest</string>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_string</key>
+				<string>%version%</string>
+				<key>find</key>
+				<string>%TAG_PREFIX%</string>
+				<key>replace</key>
+				<string></string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+			</dict>
+			<key>Processor</key>
+			<string>FindAndReplace</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
@@ -34,7 +58,7 @@
 				<key>filename</key>
 				<string>%NAME%-%version%-aarch64-apple-darwin.tar.gz</string>
 				<key>url</key>
-				<string>https://github.com/openai/codex/releases/download/rust-v%version%/codex-aarch64-apple-darwin.tar.gz</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/CodexCLI/CodexCLI.download.recipe
+++ b/CodexCLI/CodexCLI.download.recipe
@@ -40,10 +40,10 @@ a clean semver acceptable to PkgCreator.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_string</key>
-				<string>%version%</string>
 				<key>find</key>
 				<string>%TAG_PREFIX%</string>
+				<key>input_string</key>
+				<string>%version%</string>
 				<key>replace</key>
 				<string></string>
 				<key>result_output_var_name</key>


### PR DESCRIPTION
## Summary
- PR #60's revert to `URLTextSearcher` fixed the `Invalid version component` error but reintroduced GitHub API rate limiting on shared CI runners (`No match found on URL: https://api.github.com/repos/openai/codex/releases/latest` — the rate-limit response body has no `tag_name`).
- Switch back to `GitHubReleasesInfoProvider` for authenticated API access, then use core `FindAndReplace` (introduced in AutoPkg 2.7.6) to strip the `rust-v` prefix from `%version%` so `PkgCreator` gets a clean semver.
- All core AutoPkg processors; no custom shared processor.

## Test plan
- [x] Local end-to-end `autopkg run` against the IT override produces `CodexCLI-0.124.0.pkg` with `version: 0.124.0` after FindAndReplace
- [ ] Nightly AutoPkg workflow in IT repo (requires trust-info refresh follow-up)