### PR TITLE
Burp Suite: source/destination app is now 'Burp Suite.app'

### DIFF
--- a/Burp Suite Professional/Burp Suite Professional.pkg.recipe
+++ b/Burp Suite Professional/Burp Suite Professional.pkg.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Burp Suite Professional and creates a package.</string>
+	<string>Downloads the latest version of Burp Suite and creates a package.
+
+As of Burp 2026.4 PortSwigger ships a single "desktop" installer for both
+Professional and Community Edition; the edition is selected at first launch
+via license activation. The DMG and installed app are named "Burp Suite"
+(no Pro/Community suffix).</string>
 	<key>Identifier</key>
 	<string>com.rderewianko.pkg.burpsuiteprofessional</string>
 	<key>Input</key>
@@ -37,9 +42,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/Burp Suite Professional.app</string>
+				<string>%pkgroot%/Applications/Burp Suite.app</string>
 				<key>source_path</key>
-				<string>%pathname%/Burp Suite Professional.app</string>
+				<string>%pathname%/Burp Suite.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
  PortSwigger merged Professional and Community into a single 'desktop'
  installer in Burp 2026.4. The DMG and installed bundle are now named
  'Burp Suite.app' (no Pro/Community suffix); edition is chosen at first
  launch via license activation.

  Update Copier source_path and destination_path to match, so the recipe
  works against the upstream dataJAR download recipe post-#560/#561, and
  refresh the Description to explain the rename.

  Validated locally via override end-to-end:
    URLTextSearcher -> 2026.4.3
    URLDownloader   -> Burp Suite Professional/.../BurpSuiteProfessional.dmg
    CodeSignatureVerifier: Signature is valid
    Copier: copied 'Burp Suite.app'
    PkgCreator: BurpSuiteProfessional-2026.4.3.pkg