### PR TITLE
TrelicaBrowserHelper: suppress Rosetta 2 prompt on Apple Silicon

### DIFF
--- a/SharedProcessors/SetDistributionHostArchitectures.py
+++ b/SharedProcessors/SetDistributionHostArchitectures.py
@@ -1,0 +1,114 @@
+#!/usr/local/autopkg/python
+# SetDistributionHostArchitectures.py
+#
+# Sets the `hostArchitectures` attribute on the <options> element of a flat
+# pkg's Distribution file.
+#
+# Why this exists: macOS Installer.app reads `hostArchitectures` from the
+# Distribution to decide which CPU architectures the installer is allowed to
+# run on. When the attribute is missing, it defaults to x86_64-only — which
+# means installing on Apple Silicon prompts for Rosetta 2, even if every
+# binary in the payload is already universal. Adding `arm64` (or
+# `arm64,x86_64`) suppresses the prompt.
+#
+# Usage in a .pkg.recipe:
+#
+#     FlatPkgUnpacker          → expand the vendor pkg
+#     SetDistributionHostArchitectures  ← this processor
+#     FlatPkgPacker            → re-flatten the patched pkg
+#
+# Modeled on the Distribution-editing pattern in
+# autopkg/recipes/AdobeReader/AdobeReaderRepackager.py.
+
+import os
+import xml.etree.ElementTree as ET
+
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["SetDistributionHostArchitectures"]
+
+DEFAULT_ARCHES = "arm64,x86_64"
+
+
+class SetDistributionHostArchitectures(Processor):
+    """Sets the hostArchitectures attribute on the <options> element of an
+    expanded flat pkg's Distribution file, suppressing the Rosetta 2 install
+    prompt on Apple Silicon for pkgs whose vendor forgot to set it."""
+
+    description = __doc__
+    input_variables = {
+        "expanded_pkg_path": {
+            "required": True,
+            "description": (
+                "Path to an expanded flat pkg directory (the output of "
+                "FlatPkgUnpacker). Must contain a Distribution file at the "
+                "top level."
+            ),
+        },
+        "host_architectures": {
+            "required": False,
+            "description": (
+                "Comma-separated list of architectures to allow the installer "
+                "to run on. Defaults to 'arm64,x86_64'."
+            ),
+            "default": DEFAULT_ARCHES,
+        },
+    }
+    output_variables = {
+        "distribution_modified": {
+            "description": (
+                "True if the Distribution file was changed, False if the "
+                "attribute was already set to the requested value."
+            ),
+        },
+    }
+
+    def main(self):
+        expanded_pkg_path = self.env["expanded_pkg_path"]
+        arches = self.env.get("host_architectures", DEFAULT_ARCHES)
+
+        distribution_path = os.path.join(expanded_pkg_path, "Distribution")
+        if not os.path.isfile(distribution_path):
+            raise ProcessorError(
+                f"No Distribution file found at {distribution_path}. "
+                "This processor only works on distribution-style flat pkgs."
+            )
+
+        try:
+            tree = ET.parse(distribution_path)
+        except ET.ParseError as err:
+            raise ProcessorError(
+                f"Failed to parse {distribution_path}: {err}"
+            )
+
+        root = tree.getroot()
+        # The root is <installer-gui-script> (or, rarely, <installer-script>).
+        # <options> is a direct child; create it if missing.
+        options = root.find("options")
+        if options is None:
+            self.output("No <options> element found; creating one.")
+            options = ET.SubElement(root, "options")
+
+        current = options.get("hostArchitectures")
+        if current == arches:
+            self.output(
+                f"hostArchitectures already set to {arches!r}; no change."
+            )
+            self.env["distribution_modified"] = False
+            return
+
+        if current:
+            self.output(
+                f"Updating hostArchitectures: {current!r} → {arches!r}"
+            )
+        else:
+            self.output(f"Setting hostArchitectures to {arches!r}")
+        options.set("hostArchitectures", arches)
+
+        tree.write(distribution_path, encoding="utf-8", xml_declaration=True)
+        self.env["distribution_modified"] = True
+
+
+if __name__ == "__main__":
+    PROCESSOR = SetDistributionHostArchitectures()
+    PROCESSOR.execute_shell()

--- a/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
+++ b/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Trelica Browser Helper installer and copies the package to the build directory with an appended version number.</string>
+	<string>Downloads the latest Trelica Browser Helper installer, patches its Distribution to declare arm64 support (suppressing the Rosetta 2 prompt on Apple Silicon), re-flattens the pkg, and writes it to the build directory with an appended version number. Repacking strips the vendor signature; deploy via a trusted channel (MDM/Munki) or re-sign with productsign before distribution.</string>
 	<key>Identifier</key>
 	<string>com.rderewianko.pkg.TrelicaBrowserHelper</string>
 	<key>Input</key>
@@ -44,13 +44,22 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>source_pkg</key>
-				<string>%pathname%</string>
+				<key>expanded_pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/expand</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgCopier</string>
+			<string>com.rderewianko.SharedProcessors/SetDistributionHostArchitectures</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>source_flatpkg_dir</key>
+				<string>%RECIPE_CACHE_DIR%/expand</string>
+				<key>destination_pkg</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgPacker</string>
 		</dict>
 	</array>
 </dict>

--- a/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
+++ b/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
@@ -54,12 +54,23 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/repacked.pkg</string>
 				<key>source_flatpkg_dir</key>
 				<string>%RECIPE_CACHE_DIR%/expand</string>
 			</dict>
 			<key>Processor</key>
 			<string>FlatPkgPacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%RECIPE_CACHE_DIR%/repacked.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
 		</dict>
 	</array>
 </dict>

--- a/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
+++ b/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
@@ -53,10 +53,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>source_flatpkg_dir</key>
-				<string>%RECIPE_CACHE_DIR%/expand</string>
 				<key>destination_pkg</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_flatpkg_dir</key>
+				<string>%RECIPE_CACHE_DIR%/expand</string>
 			</dict>
 			<key>Processor</key>
 			<string>FlatPkgPacker</string>


### PR DESCRIPTION
## Summary

- Vendor's `TrelicaBrowserHelper.pkg` omits `hostArchitectures` from its Distribution `<options>` element. macOS Installer defaults to x86_64-only when the attribute is missing, which prompts for Rosetta 2 on Apple Silicon — even though the payload binary is already universal2 (`arm64` + `x86_64`).
- Add `SharedProcessors/SetDistributionHostArchitectures.py`, a small generic processor that injects `hostArchitectures` into an expanded flat pkg's Distribution via `xml.etree.ElementTree`. Modeled on the Distribution-editing pattern in `autopkg/recipes` `AdobeReader/AdobeReaderRepackager.py`.
- Wire it into `TrelicaBrowserHelper.pkg.recipe` between `FlatPkgUnpacker` and `FlatPkgPacker`, replacing the prior `PkgCopier` step. The download recipe's `CodeSignatureVerifier` still validates Trelica's upstream signature before repack; re-flatten naturally strips it from the output.

## Test plan

- [x] `autopkg run -vv com.rderewianko.pkg.TrelicaBrowserHelper` succeeds end-to-end
- [x] Resulting `TrelicaBrowserHelper-1.4.1.pkg` Distribution contains `hostArchitectures="arm64,x86_64"`
- [x] `pkgutil --expand` → flatten round-trip preserves the attribute
- [x] Manual install on Apple Silicon — no Rosetta 2 prompt
- [x] Helper binary still installs to `/Library/Trelica/TrelicaBrowserHelper` and native messaging manifests are written for Chrome / Edge / Firefox

## Notes

- The repacked pkg is unsigned. Deploy via a trusted channel (MDM/Munki) or chain a `productsign` step with an org Developer ID Installer cert before broad distribution.
- The `SetDistributionHostArchitectures` processor is reusable for any other vendor pkg that ships without `hostArchitectures` set.
