### PR TITLE
TrelicaBrowserHelper: drop repackaging now that vendor declares arm64

### DIFF
--- a/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
+++ b/TrelicaBrowserHelper/TrelicaBrowserHelper.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Trelica Browser Helper installer, patches its Distribution to declare arm64 support (suppressing the Rosetta 2 prompt on Apple Silicon), re-flattens the pkg, and writes it to the build directory with an appended version number. Repacking strips the vendor signature; deploy via a trusted channel (MDM/Munki) or re-sign with productsign before distribution.</string>
+	<string>Downloads the latest Trelica Browser Helper installer and writes it to the build directory with an appended version number. Trelica now declares arm64 support in the vendor pkg, so no repacking is required and the original vendor signature is preserved.</string>
 	<key>Identifier</key>
 	<string>com.rderewianko.pkg.TrelicaBrowserHelper</string>
 	<key>Input</key>
@@ -44,30 +44,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>expanded_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/expand</string>
-			</dict>
-			<key>Processor</key>
-			<string>com.rderewianko.SharedProcessors/SetDistributionHostArchitectures</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/repacked.pkg</string>
-				<key>source_flatpkg_dir</key>
-				<string>%RECIPE_CACHE_DIR%/expand</string>
-			</dict>
-			<key>Processor</key>
-			<string>FlatPkgPacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>source_pkg</key>
-				<string>%RECIPE_CACHE_DIR%/repacked.pkg</string>
+				<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>


### PR DESCRIPTION
Trelica now declares arm64 host architecture in the vendor pkg, so the Distribution patch and re-flatten are no longer needed. Simplify the pkg recipe to version the downloaded pkg and copy it directly, preserving the original vendor signature. The SetDistributionHostArchitectures shared processor is retained in the SharedProcessors repo but no longer invoked.