### PR TITLE
Bagel: resolve bundled payload via FetchScriptsPath for override safety

### DIFF
--- a/Bagel/Bagel.pkg.recipe
+++ b/Bagel/Bagel.pkg.recipe
@@ -35,6 +35,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>dirname</key>
+				<string>.</string>
+			</dict>
+			<key>Comment</key>
+			<string>Resolve this recipe's own directory (override-safe) into %dirpath%, since %RECIPE_DIR% points at the override location.</string>
+			<key>Processor</key>
+			<string>FetchScriptsPath</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkgdirs</key>
 				<dict>
 					<key>Library/LaunchAgents</key>
@@ -67,7 +78,7 @@
 				<key>overwrite</key>
 				<true/>
 				<key>source_path</key>
-				<string>%RECIPE_DIR%/payload/usr/local/bin/bagel-scan</string>
+				<string>%dirpath%/payload/usr/local/bin/bagel-scan</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -80,7 +91,7 @@
 				<key>overwrite</key>
 				<true/>
 				<key>source_path</key>
-				<string>%RECIPE_DIR%/payload/Library/LaunchAgents/zip.recyclebin.bagel.plist</string>
+				<string>%dirpath%/payload/Library/LaunchAgents/zip.recyclebin.bagel.plist</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -134,7 +145,7 @@
 					<key>pkgtype</key>
 					<string>flat</string>
 					<key>scripts</key>
-					<string>%RECIPE_DIR%/scripts</string>
+					<string>%dirpath%/scripts</string>
 					<key>version</key>
 					<string>%version%</string>
 				</dict>


### PR DESCRIPTION
## Problem
The Bagel pkg recipe (added in #71) references its bundled `payload/` and `scripts/` via `%RECIPE_DIR%`. When run through an **override**, `%RECIPE_DIR%` resolves to the override's directory (e.g. `~/Library/AutoPkg/RecipeOverrides/`), not the recipe folder — so `Copier` fails:

```
Processor: Copier: Error: Error processing path
'.../RecipeOverrides/payload/usr/local/bin/bagel-scan' with glob.
```

This breaks production runs, which execute the override rather than the recipe in place.

## Fix
Add a small local `FetchScriptsPath` processor (same pattern already used by the Drovio recipe). It resolves the recipe's *own* directory via the processor file's location — which AutoPkg finds by searching parent-recipe dirs — and exposes it as `%dirpath%`. The two `Copier` `source_path`s and `PkgCreator`'s `scripts` now use `%dirpath%/...` instead of `%RECIPE_DIR%/...`.

## Testing
Built end-to-end through an override located in a **separate directory** from the recipe (reproducing the production failure). `FetchScriptsPath` resolved the real recipe dir, both `Copier` steps succeeded, and the resulting `Bagel-0.7.0.pkg` contained `usr/local/bin/bagel`, `usr/local/bin/bagel-scan`, `Library/LaunchAgents/zip.recyclebin.bagel.plist`, and the `postinstall` script.