### PR TITLE
Fix PkgCreator ids ending in .pkg (Fleet title collision)

### DIFF
--- a/CodexCLI/CodexCLI.pkg.recipe
+++ b/CodexCLI/CodexCLI.pkg.recipe
@@ -71,7 +71,7 @@
 						</dict>
 					</array>
 					<key>id</key>
-					<string>com.openai.codex.pkg</string>
+					<string>com.openai.codexcli</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/VideoCopilot/FXConsole.pkg.recipe
+++ b/VideoCopilot/FXConsole.pkg.recipe
@@ -81,7 +81,7 @@
 						</dict>
 					</array>
 					<key>id</key>
-					<string>net.videocopilot.FXConsole.pkg</string>
+					<string>net.videocopilot.FXConsole</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>


### PR DESCRIPTION
## Problem

`CodexCLI` and `FXConsole` build packages that contain **no `.app` bundle** (a bare `/usr/local/bin/codex` binary and a staged installer app, respectively). When Fleet ingests such a package it can't read an app name, so it falls back to the **last dotted component of the pkg receipt id** to name the software title.

Both receipt ids ended in `.pkg`:
- `com.openai.codex.pkg`
- `net.videocopilot.FXConsole.pkg`

…so Fleet named **both** software titles `pkg` and then collapsed the two different installers onto a single broken title (observed in the LayerZero Fleet instance as title 596, whose detail endpoint returns empty).

## Fix

Give each `PkgCreator` a proper receipt id that does **not** end in `.pkg` and is distinct:

| recipe | old id | new id |
|---|---|---|
| `CodexCLI/CodexCLI.pkg.recipe` | `com.openai.codex.pkg` | `com.openai.codexcli` |
| `VideoCopilot/FXConsole.pkg.recipe` | `net.videocopilot.FXConsole.pkg` | `net.videocopilot.FXConsole` |

`com.openai.codexcli` is also deliberately distinct from the Codex **desktop** app's `com.openai.codex` so the CLI and the app remain separate titles.

## Notes / downstream
- Changing the receipt id changes the pkg's installed receipt, so Kandji (audit/enforce) and Fleet will treat existing installs as a fresh id once — a one-time re-install on already-managed hosts.
- The IT-repo overrides (`com-rderewianko-pkg-CodexCLI.override.recipe`, `com-rderewianko-pkg-FXConsole.override.recipe`) carry parent trust info and run with `FAIL_RECIPES_WITHOUT_TRUST_INFO=YES`, so they'll need `autopkg update-trust-info` after this merges.

## Testing
- `plutil -lint` passes on both recipes.