### PR TITLE
Add Sandwich Desktop download + pkg recipes

### DIFF
--- a/SandwichDesktop/SandwichDesktop.download.recipe
+++ b/SandwichDesktop/SandwichDesktop.download.recipe
@@ -19,12 +19,12 @@ wholesale if the vendor ever changes the endpoint.</string>
 	<string>com.rderewianko.download.SandwichDesktop</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>SandwichDesktop</string>
 		<key>ARCH</key>
 		<string>arm64</string>
 		<key>DOWNLOAD_URL</key>
 		<string>https://download.sandwichtrading.com/desktop-osx-%ARCH%</string>
+		<key>NAME</key>
+		<string>SandwichDesktop</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -48,14 +48,14 @@ wholesale if the vendor ever changes the endpoint.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_path</key>
-				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 				<array>
 					<string>Developer ID Installer: Russel Rillema (FYTUSQARXG)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>
+				<key>input_path</key>
+				<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/SandwichDesktop/SandwichDesktop.download.recipe
+++ b/SandwichDesktop/SandwichDesktop.download.recipe
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest arm64 (Apple Silicon) release of Sandwich Desktop and verifies its signature.
+
+The vendor ships a notarized, signed flat .pkg directly from
+https://download.sandwichtrading.com/desktop-osx-arm64 (which 301-redirects
+to the current build on Google Cloud Storage). The download endpoint always
+serves the latest version; AutoPkg uses ETag/Last-Modified caching to detect
+new builds.
+
+Defaults to the arm64 (Apple Silicon) build. To fetch the x86_64 (Intel)
+build instead, override ARCH with "x64" (e.g. autopkg run ... -k ARCH=x64,
+or set ARCH in a recipe override). DOWNLOAD_URL can still be overridden
+wholesale if the vendor ever changes the endpoint.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.download.SandwichDesktop</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>SandwichDesktop</string>
+		<key>ARCH</key>
+		<string>arm64</string>
+		<key>DOWNLOAD_URL</key>
+		<string>https://download.sandwichtrading.com/desktop-osx-%ARCH%</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Russel Rillema (FYTUSQARXG)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SandwichDesktop/SandwichDesktop.pkg.recipe
+++ b/SandwichDesktop/SandwichDesktop.pkg.recipe
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest arm64 Sandwich Desktop release and produces a version-stamped copy of the vendor's notarized installer pkg.
+
+The vendor already distributes a signed, notarized flat .pkg that installs
+Sandwich Desktop.app to /Applications, so this recipe does NOT rebuild the
+package (which would strip the vendor's signature/notarization). Instead it
+unpacks the payload only to read the app's version, then copies the original
+downloaded .pkg to %NAME%-%version%.pkg so downstream munki/jss recipes have
+a real version to work with.</string>
+	<key>Identifier</key>
+	<string>com.rderewianko.pkg.SandwichDesktop</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>SandwichDesktop</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.rderewianko.download.SandwichDesktop</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/1.pkg/Payload</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Sandwich Desktop.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+					<string>%RECIPE_CACHE_DIR%/payload</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SandwichDesktop/SandwichDesktop.pkg.recipe
+++ b/SandwichDesktop/SandwichDesktop.pkg.recipe
@@ -27,10 +27,10 @@ a real version to work with.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>flat_pkg_path</key>
-				<string>%pathname%</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -40,10 +40,10 @@ a real version to work with.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/1.pkg/Payload</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/1.pkg/Payload</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>
@@ -64,10 +64,10 @@ a real version to work with.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>source_pkg</key>
-				<string>%pathname%</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>


### PR DESCRIPTION
## Summary
Adds AutoPkg `download` + `pkg` recipes for [Sandwich Desktop](https://www.sandwichtrading.com/downloads-v2).

- **`SandwichDesktop.download.recipe`** — downloads from the vendor's `download.sandwichtrading.com` endpoint and verifies the signature (`Developer ID Installer: Russel Rillema (FYTUSQARXG)`, notarized).
- **`SandwichDesktop.pkg.recipe`** — the vendor already ships a signed, notarized flat `.pkg`, so this re-exports the original installer under a version-stamped name (reading the version `2.0.1.0` from the app payload) rather than rebuilding it, which would strip the notarization.

## Architecture flag
`ARCH` input defaults to `arm64` (Apple Silicon). Override with `-k ARCH=x64` (or in a recipe override) for the Intel build.

## Testing
- `plutil -lint` passes on both recipes.
- `autopkg run` of the pkg recipe succeeds for both arm64 and x64 — signature verifies, version extracted, versioned pkg produced.