### PR TITLE
CodexCLI: add x86_64 support and code signature verification

### DIFF
--- a/CodexCLI/CodexCLI.download.recipe
+++ b/CodexCLI/CodexCLI.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI from GitHub.
+	<string>Downloads the latest release of Codex CLI from GitHub. Set ARCH to either: arm64 or x86_64
 
 Uses GitHubReleasesInfoProvider for authenticated API calls (avoids the
 60-req/hour unauthenticated rate limit on shared CI runners), then
@@ -13,8 +13,8 @@ a clean semver acceptable to PkgCreator.</string>
 	<string>com.rderewianko.download.CodexCLI</string>
 	<key>Input</key>
 	<dict>
-		<key>ASSET_REGEX</key>
-		<string>^codex-aarch64-apple-darwin\.tar\.gz$</string>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>GITHUB_REPO</key>
 		<string>openai/codex</string>
 		<key>NAME</key>
@@ -29,8 +29,23 @@ a clean semver acceptable to PkgCreator.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>find</key>
+				<string>arm64</string>
+				<key>input_string</key>
+				<string>%ARCH%</string>
+				<key>replace</key>
+				<string>aarch64</string>
+				<key>result_output_var_name</key>
+				<string>DOWNLOAD_ARCH</string>
+			</dict>
+			<key>Processor</key>
+			<string>FindAndReplace</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>asset_regex</key>
-				<string>%ASSET_REGEX%</string>
+				<string>^codex-%DOWNLOAD_ARCH%-apple-darwin\.tar\.gz$</string>
 				<key>github_repo</key>
 				<string>%GITHUB_REPO%</string>
 			</dict>
@@ -56,7 +71,7 @@ a clean semver acceptable to PkgCreator.</string>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%-aarch64-apple-darwin.tar.gz</string>
+				<string>%NAME%-%version%-%DOWNLOAD_ARCH%-apple-darwin.tar.gz</string>
 				<key>url</key>
 				<string>%url%</string>
 			</dict>
@@ -83,8 +98,19 @@ a clean semver acceptable to PkgCreator.</string>
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/unarchived/codex-%DOWNLOAD_ARCH%-apple-darwin</string>
+				<key>requirement</key>
+				<string>identifier "codex" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2DC432GLL2"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>quarantined_files_path</key>
-				<string>%RECIPE_CACHE_DIR%/unarchived/codex-aarch64-apple-darwin</string>
+				<string>%RECIPE_CACHE_DIR%/unarchived/codex-%DOWNLOAD_ARCH%-apple-darwin</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.dataJAR-recipes.Shared Processors/QuarantineRemover</string>

--- a/CodexCLI/CodexCLI.pkg.recipe
+++ b/CodexCLI/CodexCLI.pkg.recipe
@@ -3,16 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI and creates a package that installs the binary to /usr/local/bin.</string>
+	<string>Downloads the latest release of Codex CLI and creates a package that installs the binary to /usr/local/bin. Set ARCH to either: arm64 or x86_64</string>
 	<key>Identifier</key>
 	<string>com.rderewianko.pkg.CodexCLI</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>CodexCLI</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>2.7.6</string>
 	<key>ParentRecipe</key>
 	<string>com.rderewianko.download.CodexCLI</string>
 	<key>Process</key>
@@ -37,7 +39,7 @@
 				<key>destination_path</key>
 				<string>%pkgroot%/usr/local/bin/codex</string>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/unarchived/codex-aarch64-apple-darwin</string>
+				<string>%RECIPE_CACHE_DIR%/unarchived/codex-%DOWNLOAD_ARCH%-apple-darwin</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -75,7 +77,7 @@
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
+					<string>%NAME%-%ARCH%-%version%</string>
 					<key>version</key>
 					<string>%version%</string>
 				</dict>
@@ -89,7 +91,6 @@
 				<key>path_list</key>
 				<array>
 					<string>%RECIPE_CACHE_DIR%/unarchived</string>
-					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 				</array>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
- Adds an ARCH variable for dual architecture support.
- Adds CodeSignatureVerifier
- Leaves the `pkgroot` folder behind so it can be used by the downstream Munki recipe to build an installs array